### PR TITLE
AsyncWorker, ObjectReference, FunctionReference classes

### DIFF
--- a/napi-inl.h
+++ b/napi-inl.h
@@ -420,7 +420,11 @@ inline Value Object::operator [](const std::string& name) const {
   return Get(name);
 }
 
-inline bool Object::Has(const PropertyName& name) const {
+inline Value Object::operator [](uint32_t index) const {
+  return Get(index);
+}
+
+inline bool Object::Has(napi_propertyname name) const {
   bool result;
   napi_status status = napi_has_property(_env, _value, name, &result);
   if (status != napi_ok) throw Error::New(Env());
@@ -435,7 +439,7 @@ inline bool Object::Has(const std::string& utf8name) const {
   return Has(PropertyName(_env, utf8name));
 }
 
-inline Value Object::Get(const PropertyName& name) const {
+inline Value Object::Get(napi_propertyname name) const {
   napi_value result;
   napi_status status = napi_get_property(_env, _value, name, &result);
   if (status != napi_ok) throw Error::New(Env());
@@ -450,12 +454,12 @@ inline Value Object::Get(const std::string& utf8name) const {
   return Get(PropertyName(_env, utf8name));
 }
 
-inline void Object::Set(const PropertyName& name, const Value& value) {
+inline void Object::Set(napi_propertyname name, napi_value value) {
   napi_status status = napi_set_property(_env, _value, name, value);
   if (status != napi_ok) throw Error::New(Env());
 }
 
-inline void Object::Set(const char* utf8name, const Value& value) {
+inline void Object::Set(const char* utf8name, napi_value value) {
   Set(PropertyName(_env, utf8name), value);
 }
 
@@ -471,7 +475,7 @@ inline void Object::Set(const char* utf8name, double numberValue) {
   Set(PropertyName(_env, utf8name), Number::New(Env(), numberValue));
 }
 
-inline void Object::Set(const std::string& utf8name, const Value& value) {
+inline void Object::Set(const std::string& utf8name, napi_value value) {
   Set(PropertyName(_env, utf8name), value);
 }
 
@@ -485,6 +489,41 @@ inline void Object::Set(const std::string& utf8name, bool boolValue) {
 
 inline void Object::Set(const std::string& utf8name, double numberValue) {
   Set(PropertyName(_env, utf8name), Number::New(Env(), numberValue));
+}
+
+inline bool Object::Has(uint32_t index) const {
+  bool result;
+  napi_status status = napi_has_element(_env, _value, index, &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return result;
+}
+
+inline Value Object::Get(uint32_t index) const {
+  napi_value value;
+  napi_status status = napi_get_element(_env, _value, index, &value);
+  if (status != napi_ok) throw Error::New(Env());
+  return Value(_env, value);
+}
+
+inline void Object::Set(uint32_t index, napi_value value) {
+  napi_status status = napi_set_element(_env, _value, index, value);
+  if (status != napi_ok) throw Error::New(Env());
+}
+
+inline void Object::Set(uint32_t index, const char* utf8value) {
+  Set(index, static_cast<napi_value>(String::New(Env(), utf8value)));
+}
+
+inline void Object::Set(uint32_t index, const std::string& utf8value) {
+  Set(index, static_cast<napi_value>(String::New(Env(), utf8value)));
+}
+
+inline void Object::Set(uint32_t index, bool boolValue) {
+  Set(index, static_cast<napi_value>(Boolean::New(Env(), boolValue)));
+}
+
+inline void Object::Set(uint32_t index, double numberValue) {
+  Set(index, static_cast<napi_value>(Number::New(Env(), numberValue)));
 }
 
 inline void Object::DefineProperty(const PropertyDescriptor& property) {
@@ -556,50 +595,11 @@ inline Array::Array() : Object() {
 inline Array::Array(napi_env env, napi_value value) : Object(env, value) {
 }
 
-inline Value Array::operator [](uint32_t index) const {
-  return Get(index);
-}
-
 inline uint32_t Array::Length() const {
   uint32_t result;
   napi_status status = napi_get_array_length(_env, _value, &result);
   if (status != napi_ok) throw Error::New(Env());
   return result;
-}
-
-inline bool Array::Has(uint32_t index) const {
-  bool result;
-  napi_status status = napi_has_element(_env, _value, index, &result);
-  if (status != napi_ok) throw Error::New(Env());
-  return result;
-}
-
-inline Value Array::Get(uint32_t index) const {
-  napi_value value;
-  napi_status status = napi_get_element(_env, _value, index, &value);
-  if (status != napi_ok) throw Error::New(Env());
-  return Value(_env, value);
-}
-
-inline void Array::Set(uint32_t index, const Value& value) {
-  napi_status status = napi_set_element(_env, _value, index, value);
-  if (status != napi_ok) throw Error::New(Env());
-}
-
-inline void Array::Set(uint32_t index, const char* utf8value) {
-  Set(index, String::New(Env(), utf8value));
-}
-
-inline void Array::Set(uint32_t index, const std::string& utf8value) {
-  Set(index, String::New(Env(), utf8value));
-}
-
-inline void Array::Set(uint32_t index, bool boolValue) {
-  Set(index, Boolean::New(Env(), boolValue));
-}
-
-inline void Array::Set(uint32_t index, double numberValue) {
-  Set(index, Number::New(Env(), numberValue));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -873,6 +873,36 @@ inline Function::Function() : Object() {
 inline Function::Function(napi_env env, napi_value value) : Object(env, value) {
 }
 
+inline napi_value Function::operator ()(
+    napi_value recv, const std::vector<napi_value>& args) const {
+  return Call(recv, args);
+}
+
+inline napi_value Function::Call(napi_value recv, const std::vector<napi_value>& args) const {
+  napi_value result;
+  napi_status status = napi_call_function(
+    _env, recv, _value, args.size(), const_cast<napi_value*>(args.data()), &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return result;
+}
+
+inline napi_value Function::MakeCallback(
+    napi_value recv, const std::vector<napi_value>& args) const {
+  napi_value result;
+  napi_status status = napi_make_callback(
+    _env, recv, _value, args.size(), const_cast<napi_value*>(args.data()), &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return result;
+}
+
+inline napi_value Function::New(const std::vector<napi_value>& args) {
+  napi_value result;
+  napi_status status = napi_new_instance(
+    _env, _value, args.size(), const_cast<napi_value*>(args.data()), &result);
+  if (status != napi_ok) throw Error::New(Env());
+  return result;
+}
+
 inline Value Function::operator ()(const std::vector<Value>& args) const {
   return Call(args);
 }
@@ -894,19 +924,17 @@ inline Value Function::Call(Object& recv, const std::vector<Value>& args) const 
     argv.push_back(args[i]);
   }
 
-  napi_value result;
-  napi_status status = napi_call_function(_env, recv, _value, argv.size(), argv.data(), &result);
-  if (status != napi_ok) throw Error::New(Env());
+  napi_value result = Call(recv, argv);
   return Value(_env, result);
 }
 
 inline Value Function::MakeCallback(const std::vector<Value>& args) const {
-  Value global = Env().Global();
+  Object global = Env().Global();
   return MakeCallback(global, args);
 }
 
 inline Value Function::MakeCallback(
-  Value& recv, const std::vector<Value>& args) const {
+  Object& recv, const std::vector<Value>& args) const {
   // Convert args from Value to napi_value.
   std::vector<napi_value> argv;
   argv.reserve(args.size());
@@ -914,9 +942,7 @@ inline Value Function::MakeCallback(
     argv.push_back(args[i]);
   }
 
-  napi_value result;
-  napi_status status = napi_make_callback(_env, recv, _value, argv.size(), argv.data(), &result);
-  if (status != napi_ok) throw Error::New(Env());
+  napi_value result = MakeCallback(recv, argv);
   return Value(_env, result);
 }
 
@@ -928,9 +954,7 @@ inline Object Function::New(const std::vector<Value>& args) {
     argv.push_back(args[i]);
   }
 
-  napi_value result;
-  napi_status status = napi_new_instance(_env, _value, argv.size(), argv.data(), &result);
-  if (status != napi_ok) throw Error::New(Env());
+  napi_value result = New(argv);
   return Object(_env, result);
 }
 
@@ -992,10 +1016,11 @@ inline Buffer Buffer::Copy(Napi::Env env, const char* data, size_t size) {
   return Buffer(env, value);
 }
 
-inline Buffer::Buffer() : Object() {
+inline Buffer::Buffer() : Object(), _length(0), _data(nullptr) {
 }
 
-inline Buffer::Buffer(napi_env env, napi_value value) : Object(env, value) {
+inline Buffer::Buffer(napi_env env, napi_value value)
+  : Object(env, value), _length(0), _data(nullptr) {
 }
 
 inline size_t Buffer::Length() const {
@@ -1282,9 +1307,213 @@ inline Reference<T> Weak(T value) {
   return Reference<T>::New(value, 0);
 }
 
+inline ObjectReference Weak(Object value) {
+  return Reference<Object>::New(value, 0);
+}
+
+inline FunctionReference Weak(Function value) {
+  return Reference<Function>::New(value, 0);
+}
+
 template <typename T>
 inline Reference<T> Persistent(T value) {
   return Reference<T>::New(value, 1);
+}
+
+inline ObjectReference Persistent(Object value) {
+  return Reference<Object>::New(value, 1);
+}
+
+inline FunctionReference Persistent(Function value) {
+  return Reference<Function>::New(value, 1);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ObjectReference class
+////////////////////////////////////////////////////////////////////////////////
+
+inline ObjectReference::ObjectReference(): Reference<Object>() {
+}
+
+inline ObjectReference::ObjectReference(napi_env env, napi_ref ref): Reference<Object>(env, ref) {
+}
+
+inline ObjectReference::ObjectReference(Reference<Object>&& other)
+  : Reference<Object>(std::move(other)) {
+}
+
+inline ObjectReference& ObjectReference::operator =(Reference<Object>&& other) {
+  static_cast<Reference<Object>*>(this)->operator=(std::move(other));
+  return *this;
+}
+
+inline ObjectReference::ObjectReference(ObjectReference&& other)
+  : Reference<Object>(std::move(other)) {
+}
+
+inline ObjectReference& ObjectReference::operator =(ObjectReference&& other) {
+  static_cast<Reference<Object>*>(this)->operator=(std::move(other));
+  return *this;
+}
+
+inline Napi::Value ObjectReference::Get(const char* utf8name) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Get(utf8name));
+}
+
+inline Napi::Value ObjectReference::Get(const std::string& utf8name) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Get(utf8name));
+}
+
+inline void ObjectReference::Set(const char* utf8name, napi_value value) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, value);
+}
+
+inline void ObjectReference::Set(const char* utf8name, const char* utf8value) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, utf8value);
+}
+
+inline void ObjectReference::Set(const char* utf8name, bool boolValue) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, boolValue);
+}
+
+inline void ObjectReference::Set(const char* utf8name, double numberValue) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, numberValue);
+}
+
+inline void ObjectReference::Set(const std::string& utf8name, napi_value value) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, value);
+}
+
+inline void ObjectReference::Set(const std::string& utf8name, std::string& utf8value) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, utf8value);
+}
+
+inline void ObjectReference::Set(const std::string& utf8name, bool boolValue) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, boolValue);
+}
+
+inline void ObjectReference::Set(const std::string& utf8name, double numberValue) {
+  HandleScope scope(Env());
+  Value().Set(utf8name, numberValue);
+}
+
+inline Napi::Value ObjectReference::Get(uint32_t index) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Get(index));
+}
+
+inline void ObjectReference::Set(uint32_t index, napi_value value) {
+  HandleScope scope(Env());
+  Value().Set(index, value);
+}
+
+inline void ObjectReference::Set(uint32_t index, const char* utf8value) {
+  HandleScope scope(Env());
+  Value().Set(index, utf8value);
+}
+
+inline void ObjectReference::Set(uint32_t index, const std::string& utf8value) {
+  HandleScope scope(Env());
+  Value().Set(index, utf8value);
+}
+
+inline void ObjectReference::Set(uint32_t index, bool boolValue) {
+  HandleScope scope(Env());
+  Value().Set(index, boolValue);
+}
+
+inline void ObjectReference::Set(uint32_t index, double numberValue) {
+  HandleScope scope(Env());
+  Value().Set(index, numberValue);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FunctionReference class
+////////////////////////////////////////////////////////////////////////////////
+
+inline FunctionReference::FunctionReference(): Reference<Function>() {
+}
+
+inline FunctionReference::FunctionReference(napi_env env, napi_ref ref)
+  : Reference<Function>(env, ref) {
+}
+
+inline FunctionReference::FunctionReference(Reference<Function>&& other)
+  : Reference<Function>(std::move(other)) {
+}
+
+inline FunctionReference& FunctionReference::operator =(Reference<Function>&& other) {
+  static_cast<Reference<Function>*>(this)->operator=(std::move(other));
+  return *this;
+}
+
+inline FunctionReference::FunctionReference(FunctionReference&& other)
+  : Reference<Function>(std::move(other)) {
+}
+
+inline FunctionReference& FunctionReference::operator =(FunctionReference&& other) {
+  static_cast<Reference<Function>*>(this)->operator=(std::move(other));
+  return *this;
+}
+
+inline napi_value FunctionReference::operator ()(
+    napi_value recv, const std::vector<napi_value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value()(recv, args));
+}
+
+inline napi_value FunctionReference::Call(
+    napi_value recv, const std::vector<napi_value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Call(recv, args));
+}
+
+inline napi_value FunctionReference::MakeCallback(
+    napi_value recv, const std::vector<napi_value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().MakeCallback(recv, args));
+}
+
+inline Napi::Value FunctionReference::operator ()(const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value()(args));
+}
+
+inline Napi::Value FunctionReference::operator ()(
+    Object& recv, const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value()(recv, args));
+}
+
+inline Napi::Value FunctionReference::Call(const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Call(args));
+}
+
+inline Napi::Value FunctionReference::Call(
+    Object& recv, const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().Call(recv, args));
+}
+
+inline Napi::Value FunctionReference::MakeCallback(const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().MakeCallback(args));
+}
+
+inline Napi::Value FunctionReference::MakeCallback(
+    Object& recv, const std::vector<Napi::Value>& args) const {
+  EscapableHandleScope scope(Env());
+  return scope.Escape(Value().MakeCallback(recv, args));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1772,20 +2001,21 @@ inline Env EscapableHandleScope::Env() const {
   return Napi::Env(_env);
 }
 
-inline Value EscapableHandleScope::Escape(Value escapee) {
+inline Value EscapableHandleScope::Escape(napi_value escapee) {
   napi_value result;
   napi_status status = napi_escape_handle(_env, _scope, escapee, &result);
   if (status != napi_ok) throw Error::New(Env());
   return Value(_env, result);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // AsyncWorker class
 ////////////////////////////////////////////////////////////////////////////////
 
-inline AsyncWorker::AsyncWorker(const Function& callback) : _env(callback.Env()) {
-  _persistent = Napi::Persistent(Object::New(Env()));
+inline AsyncWorker::AsyncWorker(const Function& callback)
+  : _env(callback.Env()),
+    _persistent(Napi::Persistent(Object::New(callback.Env()))),
+    _callback(Napi::Persistent(callback)) {
   _work = napi_create_async_work();
 }
 
@@ -1831,26 +2061,27 @@ inline void AsyncWorker::Queue() {
 }
 
 inline void AsyncWorker::WorkComplete() {
+  HandleScope scope(Env());
   if (_errmsg.size() == 0) {
-    HandleOKCallback();
+    OnOK();
   }
   else {
-    HandleErrorCallback();
+    OnError();
   }
 }
 
-inline Object AsyncWorker::Persistent() {
-  return _persistent.Value();
+inline ObjectReference& AsyncWorker::Persistent() {
+  return _persistent;
 }
 
-inline void AsyncWorker::HandleOKCallback() {
-  _callback.Value().MakeCallback({});
+inline void AsyncWorker::OnOK() {
+  _callback.MakeCallback(Env().Global(), std::vector<napi_value>());
 }
 
-inline void AsyncWorker::HandleErrorCallback() {
-  _callback.Value().MakeCallback({
+inline void AsyncWorker::OnError() {
+  _callback.MakeCallback(Env().Global(), std::vector<napi_value>({
     Error::New(Env(), _errmsg),
-  });
+  }));
 }
 
 inline void AsyncWorker::SetErrorMessage(const std::string& msg) {

--- a/napi.h
+++ b/napi.h
@@ -53,7 +53,7 @@ namespace Napi {
    */
   class Env {
   public:
-    explicit Env(napi_env env);
+    Env(napi_env env);
 
     operator napi_env() const;
 
@@ -186,22 +186,31 @@ namespace Napi {
 
     Value operator [](const char* name) const;
     Value operator [](const std::string& name) const;
+    Value operator [](uint32_t index) const;
 
-    bool Has(const PropertyName& name) const;
+    bool Has(napi_propertyname name) const;
     bool Has(const char* utf8name) const;
     bool Has(const std::string& utf8name) const;
-    Value Get(const PropertyName& name) const;
+    Value Get(napi_propertyname name) const;
     Value Get(const char* utf8name) const;
     Value Get(const std::string& utf8name) const;
-    void Set(const PropertyName& name, const Value& value);
-    void Set(const char* utf8name, const Value& value);
+    void Set(napi_propertyname name, napi_value value);
+    void Set(const char* utf8name, napi_value value);
     void Set(const char* utf8name, const char* utf8value);
     void Set(const char* utf8name, bool boolValue);
     void Set(const char* utf8name, double numberValue);
-    void Set(const std::string& utf8name, const Value& value);
+    void Set(const std::string& utf8name, napi_value value);
     void Set(const std::string& utf8name, std::string& utf8value);
     void Set(const std::string& utf8name, bool boolValue);
     void Set(const std::string& utf8name, double numberValue);
+
+    bool Has(uint32_t index) const;
+    Value Get(uint32_t index) const;
+    void Set(uint32_t index, napi_value value);
+    void Set(uint32_t index, const char* utf8value);
+    void Set(uint32_t index, const std::string& utf8value);
+    void Set(uint32_t index, bool boolValue);
+    void Set(uint32_t index, double numberValue);
 
     void DefineProperty(const PropertyDescriptor& property);
     void DefineProperties(const std::vector<PropertyDescriptor>& properties);
@@ -226,16 +235,7 @@ namespace Napi {
     Array();
     Array(napi_env env, napi_value value);
 
-    Value operator [](uint32_t index) const;
-
     uint32_t Length() const;
-    bool Has(uint32_t index) const;
-    Value Get(uint32_t index) const;
-    void Set(uint32_t index, const Value& value);
-    void Set(uint32_t index, const char* utf8value);
-    void Set(uint32_t index, const std::string& utf8value);
-    void Set(uint32_t index, bool boolValue);
-    void Set(uint32_t index, double numberValue);
   };
 
   class ArrayBuffer : public Object {
@@ -332,12 +332,17 @@ namespace Napi {
     Function();
     Function(napi_env env, napi_value value);
 
+    napi_value operator ()(napi_value recv, const std::vector<napi_value>& args) const;
+    napi_value Call(napi_value recv, const std::vector<napi_value>& args) const;
+    napi_value MakeCallback(napi_value recv, const std::vector<napi_value>& args) const;
+    napi_value New(const std::vector<napi_value>& args);
+
     Value operator ()(const std::vector<Value>& args) const;
     Value operator ()(Object& recv, const std::vector<Value>& args) const;
     Value Call(const std::vector<Value>& args) const;
     Value Call(Object& recv, const std::vector<Value>& args) const;
     Value MakeCallback(const std::vector<Value>& args) const;
-    Value MakeCallback(Value& recv, const std::vector<Value>& args) const;
+    Value MakeCallback(Object& recv, const std::vector<Value>& args) const;
     Object New(const std::vector<Napi::Value>& args);
 
   private:
@@ -347,6 +352,7 @@ namespace Napi {
     struct CallbackData {
       CallbackData(VoidFunctionCallback cb, void* data);
       CallbackData(FunctionCallback cb, void* data);
+      ~CallbackData() {};
       union {
         VoidFunctionCallback voidFunctionCallback;
         FunctionCallback functionCallback;
@@ -495,11 +501,72 @@ namespace Napi {
     bool _suppressDestruct;
   };
 
-  // Shortcut to creating a new reference with inferred type and refcount = 0.
-  template <typename T> Reference<T> Weak(T value);
+  class ObjectReference: public Reference<Object> {
+  public:
+    ObjectReference();
+    ObjectReference(napi_env env, napi_ref ref);
 
-  // Shortcut to creating a new reference with inferred type and refcount = 1.
+    // A reference can be moved but cannot be copied.
+    ObjectReference(Reference<Object>&& other);
+    ObjectReference& operator =(Reference<Object>&& other);
+    ObjectReference(ObjectReference&& other);
+    ObjectReference& operator =(ObjectReference&& other);
+    ObjectReference(const ObjectReference&) = delete;
+    ObjectReference& operator =(ObjectReference&) = delete;
+
+    Napi::Value Get(const char* utf8name) const;
+    Napi::Value Get(const std::string& utf8name) const;
+    void Set(const char* utf8name, napi_value value);
+    void Set(const char* utf8name, const char* utf8value);
+    void Set(const char* utf8name, bool boolValue);
+    void Set(const char* utf8name, double numberValue);
+    void Set(const std::string& utf8name, napi_value value);
+    void Set(const std::string& utf8name, std::string& utf8value);
+    void Set(const std::string& utf8name, bool boolValue);
+    void Set(const std::string& utf8name, double numberValue);
+
+    Napi::Value Get(uint32_t index) const;
+    void Set(uint32_t index, const napi_value value);
+    void Set(uint32_t index, const char* utf8value);
+    void Set(uint32_t index, const std::string& utf8value);
+    void Set(uint32_t index, bool boolValue);
+    void Set(uint32_t index, double numberValue);
+  };
+
+  class FunctionReference: public Reference<Function> {
+  public:
+    FunctionReference();
+    FunctionReference(napi_env env, napi_ref ref);
+
+    // A reference can be moved but cannot be copied.
+    FunctionReference(Reference<Function>&& other);
+    FunctionReference& operator =(Reference<Function>&& other);
+    FunctionReference(FunctionReference&& other);
+    FunctionReference& operator =(FunctionReference&& other);
+    FunctionReference(const FunctionReference&) = delete;
+    FunctionReference& operator =(FunctionReference&) = delete;
+
+    napi_value operator ()(napi_value recv, const std::vector<napi_value>& args) const;
+    napi_value Call(napi_value recv, const std::vector<napi_value>& args) const;
+    napi_value MakeCallback(napi_value recv, const std::vector<napi_value>& args) const;
+
+    Napi::Value operator ()(const std::vector<Napi::Value>& args) const;
+    Napi::Value operator ()(Object& recv, const std::vector<Napi::Value>& args) const;
+    Napi::Value Call(const std::vector<Napi::Value>& args) const;
+    Napi::Value Call(Object& recv, const std::vector<Napi::Value>& args) const;
+    Napi::Value MakeCallback(const std::vector<Napi::Value>& args) const;
+    Napi::Value MakeCallback(Object& recv, const std::vector<Napi::Value>& args) const;
+  };
+
+  // Shortcuts to creating a new reference with inferred type and refcount = 0.
+  template <typename T> Reference<T> Weak(T value);
+  ObjectReference Weak(Object value);
+  FunctionReference Weak(Function value);
+
+  // Shortcuts to creating a new reference with inferred type and refcount = 1.
   template <typename T> Reference<T> Persistent(T value);
+  ObjectReference Persistent(Object value);
+  FunctionReference Persistent(Function value);
 
   class CallbackInfo {
   public:
@@ -694,7 +761,7 @@ namespace Napi {
     operator napi_escapable_handle_scope() const;
 
     Env Env() const;
-    Value Escape(Value escapee);
+    Value Escape(napi_value escapee);
 
   private:
     napi_env _env;
@@ -719,16 +786,19 @@ namespace Napi {
     virtual void Execute() = 0;
     virtual void WorkComplete();
 
-    Object Persistent();
+    ObjectReference& Persistent();
 
   protected:
     explicit AsyncWorker(const Function& callback);
 
-    virtual void HandleOKCallback();
-    virtual void HandleErrorCallback();
+    virtual void OnOK();
+    virtual void OnError();
 
     void SetErrorMessage(const std::string& msg);
     const std::string& ErrorMessage() const;
+
+    FunctionReference _callback;
+    ObjectReference _persistent;
 
   private:
     static void OnExecute(void* this_pointer);
@@ -737,8 +807,6 @@ namespace Napi {
 
     napi_env _env;
     napi_work _work;
-    Reference<Function> _callback;
-    Reference<Object> _persistent;
     std::string _errmsg;
   };
 

--- a/napi.h
+++ b/napi.h
@@ -701,6 +701,47 @@ namespace Napi {
     napi_escapable_handle_scope _scope;
   };
 
+  class AsyncWorker {
+  public:
+    virtual ~AsyncWorker();
+
+    // An async worker can be moved but cannot be copied.
+    AsyncWorker(AsyncWorker&& other);
+    AsyncWorker& operator =(AsyncWorker&& other);
+    AsyncWorker(const AsyncWorker&) = delete;
+    AsyncWorker& operator =(AsyncWorker&) = delete;
+
+    operator napi_work() const;
+
+    Env Env() const;
+
+    void Queue();
+    virtual void Execute() = 0;
+    virtual void WorkComplete();
+
+    Object Persistent();
+
+  protected:
+    explicit AsyncWorker(const Function& callback);
+
+    virtual void HandleOKCallback();
+    virtual void HandleErrorCallback();
+
+    void SetErrorMessage(const std::string& msg);
+    const std::string& ErrorMessage() const;
+
+  private:
+    static void OnExecute(void* this_pointer);
+    static void OnWorkComplete(void* this_pointer);
+    static void OnDestroy(void* this_pointer);
+
+    napi_env _env;
+    napi_work _work;
+    Reference<Function> _callback;
+    Reference<Object> _persistent;
+    std::string _errmsg;
+  };
+
 } // namespace Napi
 
 // Inline implementations of all the above class methods are included here.


### PR DESCRIPTION
 - Add an `AsyncWorker` class that is an equivalent of the one defined in `node_api_helpers.h` and `nan.h`, but done in the style of the other NAPI C++ wrappers.
 - Create new `ObjectReference` and `FunctionReference` classes that make it easy to get/set properties and call functions via a reference with automatic handle scoping. These are both used by `AsyncWorker`, but are also likely to be useful in other scenarios.
 - Change many method parameters to accept NAPI primitives instead of NAPI classes. Since the classes are implicitly convertible to the primitives it doesn't affect passing class instances, but it makes it easier to interop with the NAPI C APIs that only use the primitives.
 - Move the index getters and setters from `Array` to `Object`, because objects support indexed properties. This more closely matches the V8 object model anyway.

After this, we should be able to delete `node_api_helpers.h` and update any uses of the helper classes there to use the classes from here instead.